### PR TITLE
fix: work experience expansion pushes items down

### DIFF
--- a/ui/src/assets/styles/workExperience.css
+++ b/ui/src/assets/styles/workExperience.css
@@ -1,3 +1,7 @@
+.section-top {
+  justify-content: flex-start;
+}
+
 .company-logo {
   width: 36px;
   height: 36px;

--- a/ui/src/components/Experience.tsx
+++ b/ui/src/components/Experience.tsx
@@ -19,7 +19,7 @@ const Experience = () => {
   }, []);
 
   return (
-    <div className="section">
+    <div className="section section-top">
       <div className="section-title">
         <Typography variant="h3" component="h3">
           Work Experience


### PR DESCRIPTION
## Summary
- Adds `.section-top` CSS class that overrides `justify-content` to `flex-start` for the Work Experience section
- Previously, `justify-content: center` caused all cards to reposition (up and down) when any card was expanded; now only cards below the expanded item shift down

## Test plan
- Open the Work Experience section
- Click any card to expand it and verify the cards below shift down while cards above stay in place
- Collapse the card and verify the layout returns to normal

Closes #41