### PR TITLE
chore: update README with pnpm and Groq LLM docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # PersonalWebsite
 
-A personal website built to showcase projects, experience, and portfolio.
+A personal website built to showcase projects, experience, and portfolio. The site includes an AI-powered chatbot that uses [Groq](https://console.groq.com/) as the LLM provider (model: `llama-3.1-8b-instant`) to answer questions about Nikolaos Xenakis.
 
 ## Installation
 
-Ensure you have [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/) installed. Then, install the dependencies:
+Ensure you have [Node.js](https://nodejs.org/) and [pnpm](https://pnpm.io/) installed. Then, install the dependencies:
 
 ```bash
-yarn install
+pnpm install
 ```
 
 ## Development
@@ -15,15 +15,25 @@ yarn install
 Runs the app in development mode. Open [http://localhost:5173](http://localhost:5173) to view it in your browser.
 
 ```bash
-yarn run start
+pnpm start
 ```
+
+## Environment Variables
+
+Create a `.env` file in the `ui/` directory with the following:
+
+```
+VITE_GROQ_API_KEY=your_groq_api_key_here
+```
+
+Get a free API key at [console.groq.com](https://console.groq.com/).
 
 ## Build
 
 Builds the app for production to the `dist` folder. It bundles React in production mode and optimizes the build for the best performance.
 
 ```bash
-yarn run build:prod
+pnpm run build:prod
 ```
 
 ## License


### PR DESCRIPTION
## Summary
- Replaces yarn references with pnpm in all installation and development commands
- Adds a brief description of the AI chatbot and documents the Groq LLM integration
- Adds an Environment Variables section explaining how to set `VITE_GROQ_API_KEY`

## Test plan
- Read through the updated README and verify the commands and Groq setup instructions are accurate

Closes #43