### PR TITLE
feat(projects): update Recipes project with Vercel URL

### DIFF
--- a/ui/src/data/data.ts
+++ b/ui/src/data/data.ts
@@ -276,13 +276,13 @@ export const projects: Project[] = [
   },
   {
     name: "Recipes",
-    date: "2024",
-    url: "https://nikosxenakis.github.io/recipes/",
+    date: "2024 - Present",
+    url: "https://recipes-nikosxenakis.vercel.app/",
     githubUrl: "https://github.com/nikosxenakis/recipes",
-    imageUrl: "https://nikosxenakis.github.io/recipes/favicon.ico",
-    description: `A recipe website to manage and view cooking recipes.`,
+    imageUrl: "https://recipes-nikosxenakis.vercel.app/favicon.ico",
+    description: `A recipe website to manage and view cooking recipes, deployed on Vercel.`,
     descriptionShort: `A recipe website to manage and view cooking recipes.`,
-    technologies: "React,TypeScript,Node.js",
+    technologies: "React,TypeScript,Node.js,Vercel",
   },
 ];
 


### PR DESCRIPTION
## Summary
- Update the Recipes project entry in the portfolio to point at the new Vercel deployment (`https://recipes-nikosxenakis.vercel.app/`) instead of the old GitHub Pages URL.
- Refresh the image URL, date (`2024 - Present`), description, and technologies (`+ Vercel`).

## Test plan
- [ ] Verify the Recipes card on the deployed site links to the Vercel app.
- [ ] Verify the project image loads from the Vercel favicon.