### PR TITLE
feat(chatbot): switch LLM provider from Groq to Google Gemini

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
         run: pnpm run build:prod
         working-directory: ./ui
         env:
-          VITE_GROQ_API_KEY: ${{ secrets.VITE_GROQ_API_KEY }}
+          VITE_GEMINI_API_KEY: ${{ secrets.VITE_GEMINI_API_KEY }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PersonalWebsite
 
-A personal website built to showcase projects, experience, and portfolio. The site includes an AI-powered chatbot that uses [Groq](https://console.groq.com/) as the LLM provider (model: `llama-3.1-8b-instant`) to answer questions about Nikolaos Xenakis.
+A personal website built to showcase projects, experience, and portfolio. The site includes an AI-powered chatbot that uses [Google Gemini](https://ai.google.dev/) as the LLM provider (model: `gemini-2.5-flash`) to answer questions about Nikolaos Xenakis.
 
 ## Installation
 
@@ -23,10 +23,10 @@ pnpm start
 Create a `.env` file in the `ui/` directory with the following:
 
 ```
-VITE_GROQ_API_KEY=your_groq_api_key_here
+VITE_GEMINI_API_KEY=your_gemini_api_key_here
 ```
 
-Get a free API key at [console.groq.com](https://console.groq.com/).
+Get a free API key at [Google AI Studio](https://aistudio.google.com/app/apikey).
 
 ## Build
 

--- a/ui/src/components/Chatbot.tsx
+++ b/ui/src/components/Chatbot.tsx
@@ -4,6 +4,12 @@ import { prompt } from "@/data/prompt";
 import { RiRefreshLine, RiRobot2Line, RiSubtractLine } from "react-icons/ri";
 
 type ChatMessage = { text: string; sender: "user" | "bot" };
+
+type GeminiPart = { text?: string };
+type GeminiResponse = {
+  candidates?: { content?: { parts?: GeminiPart[] } }[];
+};
+
 const STORAGE_KEY = "nikos-chatbot-messages";
 
 const SUGGESTIONS = [
@@ -62,17 +68,18 @@ const Chatbot = () => {
   };
 
   const buildPayload = (question: string) => ({
-    model: "llama-3.1-8b-instant",
-    temperature: 0.3,
-    max_tokens: 150,
-    messages: [
-      { role: "system", content: prompt },
+    systemInstruction: { parts: [{ text: prompt }] },
+    contents: [
       ...messages.map((message) => ({
-        role: message.sender === "user" ? "user" : "assistant",
-        content: message.text,
+        role: message.sender === "user" ? "user" : "model",
+        parts: [{ text: message.text }],
       })),
-      { role: "user", content: question },
+      { role: "user", parts: [{ text: question }] },
     ],
+    generationConfig: {
+      temperature: 0.3,
+      maxOutputTokens: 150,
+    },
   });
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -105,21 +112,19 @@ const Chatbot = () => {
     setIsLoading(true);
     setError(null);
 
-    const apiKey = import.meta.env.VITE_GROQ_API_KEY;
+    const apiKey = import.meta.env.VITE_GEMINI_API_KEY;
 
     if (!apiKey) {
-      setError("Missing VITE_GROQ_API_KEY. Add it to your environment to enable chat.");
+      setError("Missing VITE_GEMINI_API_KEY. Add it to your environment to enable chat.");
       setIsLoading(false);
       return;
     }
 
     try {
-      const response = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${encodeURIComponent(apiKey)}`;
+      const response = await fetch(url, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(buildPayload(userMessage.text)),
       });
 
@@ -127,10 +132,12 @@ const Chatbot = () => {
         throw new Error(`Request failed: ${response.status}`);
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as GeminiResponse;
       const botReply =
-        data?.choices?.[0]?.message?.content?.trim() ??
-        "I had trouble formulating a response. Please try again.";
+        data.candidates?.[0]?.content?.parts
+          ?.map((part) => part.text ?? "")
+          .join("")
+          .trim() || "I had trouble formulating a response. Please try again.";
 
       setMessages([...updatedMessages, { text: botReply, sender: "bot" }]);
     } catch {


### PR DESCRIPTION
## Summary
- Swap the chatbot LLM provider from Groq (`llama-3.1-8b-instant`) to Google Gemini (`gemini-2.5-flash`), mirroring the approach used in the `recipes` project.
- Rename the build-time secret from `VITE_GROQ_API_KEY` to `VITE_GEMINI_API_KEY` in the chatbot, README, and GitHub Pages deploy workflow.

## Action required before merge
- Add a `VITE_GEMINI_API_KEY` secret to the repository (Settings → Secrets and variables → Actions). The old `VITE_GROQ_API_KEY` secret can be removed once this lands.

## Test plan
- [ ] Locally export `VITE_GEMINI_API_KEY` and verify the chatbot returns answers using Gemini.
- [ ] Verify the suggestion chips still work and conversation history is sent in the new Gemini `contents` format.